### PR TITLE
Remove unsupported debugger gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,6 @@ group :development do
   gem "foreman"
   gem "letter_opener"
   gem "rails-erd"
-  gem "debugger"
   gem 'mysql2'
 
   # YARD AND REDCLOTH are for generating yardocs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
     cocaine (0.5.4)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.0)
-    columnize (0.3.6)
     compass (0.12.5)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
@@ -91,12 +90,6 @@ GEM
       compass (>= 0.12.2)
       sprockets (<= 2.11.0)
     database_cleaner (1.2.0)
-    debugger (1.6.6)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.2)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.2)
     diff-lcs (1.1.3)
     dotenv (0.10.0)
     dynamic_form (1.1.4)
@@ -318,7 +311,6 @@ DEPENDENCIES
   compass (~> 0.12.2)
   compass-rails (~> 1.1.3)
   database_cleaner
-  debugger
   dynamic_form
   email_spec
   factory_girl (~> 3.3.0)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Processes are managed by the foreman gem.
 
     * First, copy the Procfile.dev.example to Procfile.dev
     * Then Make any specific local machine changes (executable paths, ports, etc)
-    * then do $ forman start -f Procfile.dev
+    * then do $ foreman start -f Procfile.dev
 
 
 ##ImageMagick and rMagick on OS X 10.8


### PR DESCRIPTION
Debugger is not supported in Ruby 2.x.x. I removed it for now as a quick fix and I am not sure what the preferred replacement would be.

https://github.com/cldwalker/debugger#known-issues
