### PR TITLE
fix issue with product type nested set options

### DIFF
--- a/app/views/admin/merchandise/product_types/_form.html.erb
+++ b/app/views/admin/merchandise/product_types/_form.html.erb
@@ -6,7 +6,7 @@
   <div class="six columns">
     <label>Parent</label>
     <%= form.select :parent_id,
-                      nested_set_options(ProductType, @product_type) {|i, level| "#{'-' * level} #{i.name}" },
+                      nested_set_options(ProductType, @product_type) {|i| "#{'-' * i.level} #{i.name}" },
                       { :include_blank => true } %>
   </div>
 </fieldset>


### PR DESCRIPTION
Fixes this error I have been having.

```
ActionView::Template::Error (no implicit conversion from nil to integer)
```

> As documented on the gem's page, the block passed to the `nested_set_options` only accepts a single argument `i` which is the category itself. level is a method of `i` which you can get using `i.level`.
> -http://stackoverflow.com/a/20139429/1417774
