### PR TITLE
add in missing product params

### DIFF
--- a/app/controllers/admin/merchandise/products_controller.rb
+++ b/app/controllers/admin/merchandise/products_controller.rb
@@ -98,8 +98,9 @@ class Admin::Merchandise::ProductsController < Admin::BaseController
   private
 
     def allowed_params
-      params.require(:product).permit(:name, :description, :product_keywords, :set_keywords, :product_type_id,
-                                      :prototype_id, :shipping_category_id, :permalink, :available_at, :deleted_at,
+      params.require(:product).permit(:name, :description, :short_description, :reoccurring_blurb,
+                                      :product_keywords, :set_keywords, :product_type_id, :prototype_id,
+                                      :shipping_category_id, :permalink, :available_at, :deleted_at,
                                       :meta_keywords, :meta_description, :featured, :description_markup, :brand_id,
                                       product_properties_attributes: [:id, :product_id, :property_id, :position, :description])
     end


### PR DESCRIPTION
The params for a product's short_description and reoccurring_blurb were missing so they could not be saved. I added those to the list.
